### PR TITLE
升级actions/setup-node到v3

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -31,12 +31,12 @@ jobs:
     steps:
 
       - name: 1. 检查url文件
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
 
       - name: 2. 安装 Node
         uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: 16
 
       - name: 3. 安装插件
         run: |

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: 2. 安装 Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: "14.x"
 


### PR DESCRIPTION
v1 会有版本废弃警告
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/setup-node